### PR TITLE
Make SCP upload sandboxed by removing it's read to the global ssh_config(s)

### DIFF
--- a/SCP Upload.dzbundle/action.rb
+++ b/SCP Upload.dzbundle/action.rb
@@ -8,8 +8,8 @@
 # URL: http://aptonic.com
 # OptionsNIB: ExtendedLogin
 # DefaultPort: 22
-# Version: 1.0
-# RunsSandboxed: No
+# Version: 1.1
+# RunsSandboxed: Yes
 # MinDropzoneVersion: 3.0
 # UniqueID: 1009
 

--- a/SCP Upload.dzbundle/scp_uploader.rb
+++ b/SCP Upload.dzbundle/scp_uploader.rb
@@ -38,7 +38,7 @@ class SCPUploader
     alert_title = "SCP Upload Error"
     error_title = "Connection Failed"
     begin
-      Net::SSH.start(host, user, {:password => pass, :port => port}) do |ssh|
+      Net::SSH.start(host, user, {:password => pass, :port => port, :config => false}) do |ssh|
         remotedir = ssh.exec!("echo ~").strip if not remotedir
 
   	    files = []
@@ -135,7 +135,7 @@ class SCPUploader
     path_warning = ""
     
     begin
-      Net::SSH.start(host_info[:server], host_info[:username], {:password => host_info[:password], :port => host_info[:port]}) do |ssh|
+      Net::SSH.start(host_info[:server], host_info[:username], {:password => host_info[:password], :port => host_info[:port], :config => false }) do |ssh|
         if not ENV['remote_path']
           remote_path = ssh.exec!("echo ~").strip
           path_warning = "\n\nAs you have not specified a remote path, files will be uploaded to #{remote_path}."


### PR DESCRIPTION
Hello there!
I noticed this was a trivial change to make the SCP Upload plugin run in the sandbox so I disabled the SSH read of the configs and bumped the version number.

I know this could break some very advanced usage but I thought it would be better to have the SCP plugin work wholly in the sandbox and without interference with any custom configs.
