### PR TITLE
Action updated to work with Pashua

### DIFF
--- a/Clone Git Repository.dzbundle/action.rb
+++ b/Clone Git Repository.dzbundle/action.rb
@@ -3,13 +3,13 @@
 # Description: Drag the URL of a git repository onto this action and it will be cloned into the selected folder.\n\nHold the command key to select a different destination folder. Hold Shift to clone all project history.
 # Handles: Text
 # Creator: Dominique Da Silva
-# URL: https://inspira.io
+# URL: https://apps.inspira.io
 # OptionsNIB: ChooseFolder
 # SkipConfig: No
 # RunsSandboxed: No
 # Events: Dragged, Clicked
 # KeyModifiers: Command, Shift
-# Version: 1.4
+# Version: 1.5
 # MinDropzoneVersion: 3.2.1
 # UniqueID: 1031
 
@@ -31,12 +31,12 @@ def dragged
 
     # Let user select a folder to clone to
     if modifier == "Command"
-      chosen_folder = $dz.cocoa_dialog("fileselect --title \"Select a folder to clone to\" --informative-text \"Select the folder where you want git to clone this project.\" --select-directories --debug --select-only-directories --string-output --with-directory \"#{folder}\" --no-newline")
-      puts chosen_folder
-      if chosen_folder.empty?
+      selected_folder = `osascript -e 'set directory to POSIX path of (choose folder with prompt "Select the folder where you want git to clone this project." default location ("#{folder}"))' 2>/dev/null`
+
+      if selected_folder.empty?
         $dz.fail("You must select a folder")
       else
-        folder = chosen_folder
+        folder = selected_folder.strip
       end
     end
 
@@ -50,7 +50,7 @@ def dragged
 
     # Create directory if it doesn't already exist
     if File.exists?(absolute_path) and File.directory?(absolute_path)
-      puts "Project folder exists"
+      puts "Destination folder already exists."
       idx = 1
       while File.exists?(absolute_path) do
         idx += 1
@@ -72,10 +72,10 @@ def dragged
       $dz.error("Git clone failed","Git failed to clone the repository:\n#{gitclone}")
       $dz.fail("Git failed to clone the repository.")
     end
-    system("open #{absolute_path}")
+    system("open \"#{absolute_path}\"")
 
-    $dz.finish("Git project cloned to #{project_folder}")
-    $dz.url("#{absolute_path}")
+    $dz.finish("Git project cloned to #{project_folder} folder.")
+    $dz.text(absolute_path.gsub(" ", "\\ "))
   else
     $dz.fail("#{item} is not a valid URL.")
   end

--- a/Create DMG File.dzbundle/action.rb
+++ b/Create DMG File.dzbundle/action.rb
@@ -6,7 +6,7 @@
 # KeyModifiers: Option
 # Creator: Megan Cooke
 # URL: http://www.insanekitty.co.uk
-# Version: 1.0
+# Version: 1.1
 # RunsSandboxed: No
 # UniqueID: 1028
 # MinDropzoneVersion: 3.0
@@ -22,9 +22,9 @@ def dragged
 	# set the output dmg and volume name
 	dmgName = fileName + '.dmg'
 	volumeName = fileName
-	
+
 	tmpSrcDir = "#{$tmpDir}/src";
-	
+
 	# set the output files
 	tmpDmg = "#{$tmpDir}/#{dmgName}"
 	destination = ENV['HOME'] + '/Desktop'
@@ -34,7 +34,7 @@ def dragged
 		$dz.error("Directory Error.", "Unable to find the destination directory")
 		return
 	end
-	
+
 	# create the tmp directories and copy the files across
 	begin
 		# check to see if the file is a directory (and not an app), and if so then only copy the contents of that folder and not the parent dir like DropDMG
@@ -45,10 +45,10 @@ def dragged
 					# get the full path to the directory
 					files.push($items[0] + '/'  + file)
 				end
-			end	
+			end
 		end
 
-		# create the tmp dir where we will do all the work		
+		# create the tmp dir where we will do all the work
 		system("/bin/mkdir -p \"#{tmpSrcDir}\"")
 
 		# if we have passed in a directory and there are files in it, then copy those otherwise just copy the dragged src
@@ -69,7 +69,7 @@ def dragged
 
 	# create the dmg file, copy to the desktop and do some cleaning up
 	begin
-		
+
 		# create an encrypted DMG file if a modifier key is held down
 		if ENV["KEY_MODIFIERS"] != "Option"
 			$dz.determinate(false)
@@ -77,17 +77,28 @@ def dragged
 			system("hdiutil create \"#{tmpDmg}\" -volname \"#{volumeName}\" -srcfolder \"#{tmpSrcDir}\" -ov >& /dev/null")
 		else
 			# get the password
-			output = $dz.cocoa_dialog('secure-standard-inputbox ‑‑float --title "Enter a new password to secure ' + dmgName + '" --e --informative-text "If you forget this password you will not be able to access the files stored on this image.' + "\n\n" + 'Enter the password:" --button1 "Ok" --button2 "Cancel"')
-			button, password = output.split("\n")
-			
+			pconfig = "
+				*.title = DMG Image Password
+				p.type = textfield
+				p.label = Enter a new password to secure \"#{dmgName}\"
+				p.mandatory = true
+				i.type = text
+				i.default = If you forget this password you will not be able to access the files stored on this image.
+				bc.type = cancelbutton
+				bc.default = Cancel
+			"
+			$dz.begin("Waiting for the DMG Image password...")
+			output = $dz.pashua(pconfig)
+			password = output['p']
+
 			# stop on cancel
-			if button == "2"
+			if output['bc'] == '1'
 				cleanup
 				$dz.finish("Cancelled")
 				$dz.url(false)
 				return
 			end
-			
+
 			$dz.determinate(false)
 			$dz.begin("Creating Encrypted DMG file...")
 

--- a/Pushover.dzbundle/action.rb
+++ b/Pushover.dzbundle/action.rb
@@ -1,20 +1,22 @@
 # Dropzone Action Info
 # Name: Pushover
-# Description: Send message via a Pushover notification (https://pushover.net/). Hold Alt Key to select a device or Shift Key to refresh devices list.
+# Description: Send message via a Pushover notification (https://pushover.net/). Hold Alt Key to select a device, Shift Key to refresh devices list and Command key to reset settings.
 # Creator: Dominique Da Silva
-# URL: https://inspira.io
+# URL: https://apps.inspira.io
 # Events: Clicked, Dragged
-# KeyModifiers: Option, Shift
+# KeyModifiers: Command, Option, Shift
 # SkipConfig: No
 # Handles: Text
 # OptionsNIB: APIKey
 # LoginTitle: Pushover User API Key
 # RunsSandboxed: Yes
 # MinDropzoneVersion: 3.0
-# Version: 1.1
+# Version: 1.2
 # UniqueID: 7002
 
 require 'notification'
+
+@po_website = ["https://pushover.net/","https://client.pushover.net/"]
 
 def send(data)
 
@@ -29,20 +31,36 @@ def send(data)
 	notification.sound = 'none'
 
 	# Ask user if he want to display a list of device each time
-	if ask_device.nil?
-		output = $dz.cocoa_dialog('msgbox --no-cancel --title "Pushover" --text "Send notification to all devices by default ?" --informative-text "To select a device later, you can hold Shift Key to display the list of device." --button1 "Yes to all" --button2 "No, choose each time" ')
-		if output == "2\n"
-			$dz.save_value('ask_device', 'true')
-			ask_device = 'true'
-		else
+	if ask_device.nil? || modifier == 'Command'
+		pconfig = "
+			*.title = Pushover
+			txt.type = text
+			txt.default = [return]To select a device later, you can hold Alt Key to display the list of device.
+			txt.label = Send notification to all devices by default ?
+			b1.type = defaultbutton
+			b1.label = Yes to all
+			cb.type = cancelbutton
+			cb.label = No, choose each time
+		"
+		result = $dz.pashua(pconfig)
+
+		if result['b1'] == '1'
 			$dz.save_value('ask_device', 'false')
 			ask_device = 'false'
+		else
+			$dz.save_value('ask_device', 'true')
+			ask_device = 'true'
+		end
+
+		if modifier == 'Command'
+			select_prefered_website()
 		end
 	end
 
 	# DISPLAY A LIST OF DEVICES
-	# Option: Display the dropdown list
+	# Option: Display the list to select a device
 	# Shift: Update the devices from Pushover server and open the dropdown list
+	# Command: Reset user settings and prompt again
 
 	# Refresh user devices list from Pushover
 	if devices.nil? || modifier == 'Shift'
@@ -50,11 +68,53 @@ def send(data)
 	end
 
 	if ( ask_device == 'true' || modifier == 'Option' || modifier == 'Shift' ) && ! devices.nil?
-		devices_list = devices.tr(',',' ')
-		output = $dz.cocoa_dialog("dropdown --title 'Pushover' --no-cancel --text \"Select the device in the list to which to send the message.\" --float --button1 'Send' --string-output --items #{devices_list}")
-		button, device = output.split("\n")
-		puts "Selected device: "+device
-		notification.device = device
+		send_to_all_title = "All devices"
+		# Generate devices radio options
+		radio_options = ""
+		devices.split(',').each { |device|
+			radio_options = "#{radio_options}\ndevice.option = #{device}"
+		}
+		pconfig = "
+			*.title = Pushover
+			device.type = radiobutton
+			#{radio_options}
+			device.option = #{send_to_all_title}
+			device.default = #{ENV['last_device']}
+			device.tooltip = Select the device in the list to which to send the message.
+			device.mandatory = true
+			b.type = defaultbutton
+			b.label = Send
+			cb.type = cancelbutton
+			cb.label = Cancel
+			tx.type = textbox
+			tx.label = Pushover notification
+			tx.tooltip = You can modify the content of the notification here.
+			tx.default = #{data.chomp}
+			tx.width = 360
+			tx.height = 90
+		"
+		result = $dz.pashua(pconfig)
+
+		# Device selection canceled by user
+		if result['cb'] == '1'
+			$dz.fail('Sending canceled.')
+		end
+
+		device = result['device']
+		puts "Selected device: "+device.to_s
+
+		# Keep last used device
+		$dz.save_value('last_device', device)
+
+		# Specify a device for the notification
+		if device != send_to_all_title
+			notification.device = device
+		end
+
+		# Modified message
+		if not result['tx'].empty?
+			notification.message = result['tx'].gsub("[return]","\n")
+		end
 	end
 
 	notification.push # send the message
@@ -67,26 +127,35 @@ def dragged
 	send($items[0])
 end
 
+def select_prefered_website
+	pconfig = "
+		*.title = Pushover Website
+		website.type = popup
+		website.option = Pushover Client
+		website.option = Pushover Website
+		website.label = Choose the Pushover webpage to open by default.
+		t.type = text
+		t.default = For Pushover Desktop Users you can choose the client website when you click on the action, otherwise select the homepage.
+	"
+	result = $dz.pashua(pconfig)
+
+	website_choice = if result['website'] == "Pushover Client" then '1' else '0' end
+	$dz.save_value('website_choice', website_choice)
+	return website_choice
+end
+
 def clicked
 
 	# Clicked action open Pushover webpage
-	po_website = ["https://pushover.net/","https://client.pushover.net/"]
 	website_choice = ENV['website_choice']
 
 	if website_choice.nil?
-		website_choice = "0"
-		choice = $dz.cocoa_dialog('msgbox --title "Pushover Website" --text "Choose the Pushover webpage to open by default." --informative-text "For Pushover Desktop Users you can choose the client website when you click on the action, otherwire select the homepage." --button3 "Cancel" --button2 "Pushover Client" --button1 "Pushover homepage"')
-		choice = choice.to_i - 1
-
-		if choice == 0 or choice == 1 then
-			website_choice = choice.to_s
-			$dz.save_value('website_choice', choice)
-		end
+		website_choice = select_prefered_website()
 	end
 
 	choice = website_choice.to_i
-	puts "Open website "+po_website[choice]
-	system("open "+po_website[choice])
+	puts "Open website "+@po_website[choice]
+	system("open "+@po_website[choice])
 
 	# update devices
 	notification = Notification.new('pushover', ENV['api_key'])

--- a/YouTube Uploader.dzbundle/action.rb
+++ b/YouTube Uploader.dzbundle/action.rb
@@ -8,7 +8,7 @@
 # AuthScope: https://www.googleapis.com/auth/youtube.upload
 # Events: Dragged, Clicked
 # RunsSandboxed: Yes
-# Version: 2.0
+# Version: 2.1
 # UniqueID: 1026
 # MinDropzoneVersion: 3.2.1
 


### PR DESCRIPTION
I have updated the actions to work with Pashua.

**Clone Git Repository**: I used Applescript to select a folder, faster than the Pashua dialog.
**Sparse Image**: I added a function who calcul the folder size and set a default storage space.
**YouTube Uploader**: It keep the last privacy settings.
**Pushover**: The device selection dialog permit to modify the message before sending and it keep the last device selected.

PS: I don't found a way to delete a saved value. It's a pity that modifiers keys doesn't work on click.